### PR TITLE
Update mod to Minecraft 26.2 and fix build configurations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Every field you add must be added to buildSrc/src/main/groovy/multiloader-common.gradle expandProps map.
 
 # Project
-version=8.0.0
+version=8.0.1
 group=dev.boxadactleflatedit
 java_version=25
 
@@ -16,32 +16,32 @@ description=A rework of the horrific superflat creation screen.
 enabled_platforms=neoforge,fabric
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1-1
+neo_form_version=26.2-2
 
-minecraft_version=26.1.1
+minecraft_version=26.2
 minecraft_version_range=[26,27)
 minecraft_version_range_fabric=26.x
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.144.0+26.1
-fabric_loader_version=0.18.4
-modmenu_version=18.0.0-alpha.8
+fabric_version=0.156.0+26.2
+fabric_loader_version=0.19.3
+modmenu_version=20.0.1
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.0.1-beta
+neoforge_version=26.2.0.32-beta
 neoforge_loader_version_range=[4,)
 
 # BoxLib
-boxlib_version=21.0.0
-boxlib_version_range = [21, 22)
-boxlib_version_range_fabric=21.x
+boxlib_version=22.0.1
+boxlib_version_range = [21, 23)
+boxlib_version_range_fabric=22.x
 
 # Gradle
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 #publishing
-game_versions = 26.1,26.1.1
+game_versions = 26.2
 project_id_curseforge = 1261053
 project_id_modrinth = sS0r4bFm
 release_type = release

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description
This PR updates the mod and its build configurations to support Minecraft 26.2. 

The update process went smoothly, and all major platform dependencies have been bumped to their respective 26.2 releases. I also bumped the Gradle wrapper to 9.5.0 to ensure compatibility with Java 25.

### Changes Made:
* **Minecraft:** Updated `minecraft_version` and `game_versions` to `26.2`.
* **NeoForge:** Updated `neoforge_version` to `26.2.0.32-beta` and `neo_form_version` to `26.2-2`.
* **Fabric:** Updated Fabric API to `0.156.0+26.2`, Loader to `0.19.3`, and ModMenu to `20.0.1`.
* **BoxLib:** Bumped `boxlib_version` to `22.0.1` and expanded the version range to `[21, 23)` / `22.x` to support the new game version.
* **Gradle:** Updated the wrapper from `9.2.0` to `9.5.0`.
* **Project:** Bumped the mod version to `8.0.1`.

Tested and confirmed building successfully on both Fabric and NeoForge. Let me know if you need any adjustments!